### PR TITLE
Make message & type optional for triggers

### DIFF
--- a/actix-htmx/src/htmx.rs
+++ b/actix-htmx/src/htmx.rs
@@ -64,9 +64,9 @@ impl fmt::Display for SwapType {
 }
 
 struct HtmxDetailsInner {
-    standard_triggers: IndexMap<String, String>,
-    after_settle_triggers: IndexMap<String, String>,
-    after_swap_triggers: IndexMap<String, String>,
+    standard_triggers: IndexMap<String, Option<String>>,
+    after_settle_triggers: IndexMap<String, Option<String>>,
+    after_swap_triggers: IndexMap<String, Option<String>>,
     response_headers: IndexMap<String, String>,
     request_headers: IndexMap<String, DataType>,
 }
@@ -160,7 +160,8 @@ impl HtmxDetails {
         self.inner.borrow().get_string_header(RequestHeaders::HX_TRIGGER_NAME)
     }
 
-    pub fn trigger_event(&self, name: String, message: String, trigger_type: TriggerType) {
+    pub fn trigger_event(&self, name: String, message: Option<String>, trigger_type: Option<TriggerType>) {
+        let trigger_type = trigger_type.unwrap_or(TriggerType::Standard);
         match trigger_type {
             TriggerType::Standard => {
                 self.inner.borrow_mut().standard_triggers.insert(name, message);
@@ -236,7 +237,7 @@ impl HtmxDetails {
         );
     }
 
-    pub(crate) fn get_triggers(&self, trigger_type: TriggerType) -> IndexMap<String, String> {
+    pub(crate) fn get_triggers(&self, trigger_type: TriggerType) -> IndexMap<String, Option<String>> {
         match trigger_type {
             TriggerType::Standard => self.inner.borrow().standard_triggers.clone(),
             TriggerType::AfterSettle => self.inner.borrow().after_settle_triggers.clone(),

--- a/actix-htmx/src/lib.rs
+++ b/actix-htmx/src/lib.rs
@@ -33,8 +33,8 @@
 //!     }
 //!     htmx_details.trigger_event(
 //!         "my_event".to_string(),
-//!         r#"{"level": "info", "message": "my event message!"}"#.to_string(),
-//!         TriggerType::Standard
+//!         Some(r#"{"level": "info", "message": "my event message!"}"#.to_string()),
+//!         Some(TriggerType::Standard)
 //!     );
 //!
 //!     HttpResponse::Ok().content_type("text/html").body(// render the view)

--- a/actix-htmx/src/middleware.rs
+++ b/actix-htmx/src/middleware.rs
@@ -59,14 +59,19 @@ where
 
             let (req, mut res) = res.into_parts();
 
-            let trigger_json = |trigger_map: IndexMap<String, String>| -> String {
+            let trigger_json = |trigger_map: IndexMap<String, Option<String>>| -> String {
                 let mut triggers = String::new();
                 triggers.push('{');
                 trigger_map.iter().for_each(|(key, value)| {
-                    if value.trim().starts_with('{') {
-                        triggers.push_str(&format!("\"{}\": {},", key, value));
-                    } else {
-                        triggers.push_str(&format!("\"{}\": \"{}\",", key, value));
+                    if let Some(value) = value {
+                        if value.trim().starts_with('{') {
+                            triggers.push_str(&format!("\"{}\": {},", key, value));
+                        } else {
+                            triggers.push_str(&format!("\"{}\": \"{}\",", key, value));
+                        }
+                    }
+                    else {
+                        triggers.push_str(&format!("\"{}\": null,", key));
                     }
                 });
                 triggers.pop();
@@ -75,7 +80,7 @@ where
             };
 
             let mut process_trigger_header =
-                |header_name: HeaderName, trigger_map: IndexMap<String, String>| {
+                |header_name: HeaderName, trigger_map: IndexMap<String, Option<String>>| {
                     if trigger_map.is_empty() {
                         return;
                     }

--- a/examples/todo/src/routes/home/home.html
+++ b/examples/todo/src/routes/home/home.html
@@ -33,5 +33,13 @@
 <script>
     document.body.addEventListener("message", function(evt){
         console.log(evt.detail.value);
+    });
+
+    document.body.addEventListener("message2", function(evt){
+        console.log(evt.detail.value);
+    })
+
+    document.body.addEventListener("deleted", function(){
+        console.log("deleted event was triggered");
     })
 </script>

--- a/examples/todo/src/routes/todo/delete.rs
+++ b/examples/todo/src/routes/todo/delete.rs
@@ -15,9 +15,20 @@ pub async fn delete_todo(
         Ok(_) => {
             htmx_details.trigger_event(
                 "message".to_string(),
-                format!("Task with id {} was deleted", id).to_string(),
-                TriggerType::Standard,
+                Some(format!("Task with id {} was deleted", id).to_string()),
+                Some(TriggerType::Standard),
             );
+            htmx_details.trigger_event(
+                "message2".to_string(),
+                Some("Just showing you can trigger more than one event".to_string()),
+                Some(TriggerType::Standard),
+            );
+            htmx_details.trigger_event(
+                "message".to_string(),
+                Some("Another event, just for fun".to_string()),
+                Some(TriggerType::AfterSettle),
+            );
+            htmx_details.trigger_event("deleted".to_string(), None, None);
             let todos = match Todos::get_todos(&pool).await {
                 Ok(x) => x,
                 Err(_) => {

--- a/examples/todo/src/routes/todo/delete.rs
+++ b/examples/todo/src/routes/todo/delete.rs
@@ -21,7 +21,7 @@ pub async fn delete_todo(
             htmx_details.trigger_event(
                 "message2".to_string(),
                 Some("Just showing you can trigger more than one event".to_string()),
-                Some(TriggerType::Standard),
+                None,
             );
             htmx_details.trigger_event(
                 "message".to_string(),

--- a/examples/todo/src/routes/todo/put.rs
+++ b/examples/todo/src/routes/todo/put.rs
@@ -29,8 +29,8 @@ pub async fn update_todo(
         Ok(_) => {
             htmx_details.trigger_event(
                 "message".to_string(),
-                format!("Task with id {} was set to {}", id, status).to_string(),
-                TriggerType::Standard,
+                Some(format!("Task with id {} was set to {}", id, status).to_string()),
+                Some(TriggerType::Standard),
             );
             let todos = match Todos::get_todos(&pool).await {
                 Ok(x) => x,


### PR DESCRIPTION
htmx triggers don't need to have any extra details with them. By default, they'll be standard triggers.

Test Plan:
Send triggers to an htmx front end app both with and without optional parameters.
